### PR TITLE
Keep the option to enlarge the images even if user has the maximum selected

### DIFF
--- a/nuancier/static/nuancier.js
+++ b/nuancier/static/nuancier.js
@@ -17,7 +17,6 @@ function checkboxCheck(checkbox) {
             ).length + " of " + votelimit);
         $("#sidethumb-"+myid).remove();
         $(".hoveroverlay").removeClass("limit");
-        $(".resizelink").removeClass("limit");
     });
 }
 
@@ -25,7 +24,6 @@ function checkboxCheck(checkbox) {
 function updateActionAndInfo(){
     if ($('input[type=checkbox]:checked').length == votelimit) {
         $(".hoveroverlay").addClass("limit");
-        $(".resizelink").addClass("limit");
 
         $("#fix_info").html($('input[type=checkbox]:checked'
         ).length + " of " + votelimit + " -- You have reached the "


### PR DESCRIPTION
This allows the user to still zoom on a specific image even if he has already made the largest
selection allowed. This would give the user the possibility to review other image and eventually
change the selection.
