### PR TITLE
replacing http:// with // for two resources

### DIFF
--- a/doc/_static/site.css
+++ b/doc/_static/site.css
@@ -1,5 +1,5 @@
 @import url("cloud.css");
-@import url("http://fonts.googleapis.com/css?family=Comfortaa");
+@import url("//fonts.googleapis.com/css?family=Comfortaa");
 
 .nuancier-logo span {
     background: url("nuancier.png") no-repeat scroll 50% 0 transparent;

--- a/nuancier/static/koji.css
+++ b/nuancier/static/koji.css
@@ -19,7 +19,7 @@ body {
     font-size: small;
     font-family: "Liberation Sans","Lucida Grande", "Luxi Sans", "Bitstream Vera Sans", helvetica, verdana, arial, sans-serif;
     color: #666;
-    background: #fff url(http://koji.fedoraproject.org/koji-static/images/header-bg.png) repeat-x;
+    background: #fff url(//koji.fedoraproject.org/koji-static/images/header-bg.png) repeat-x;
 }
 
 a, a:visited, a:hover {

--- a/nuancier/templates/master.html
+++ b/nuancier/templates/master.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" type="text/css" media="screen"
         href="{{ url_for('static', filename='nuancier.css') }}"/>
     <link rel='stylesheet' type='text/css'
-         href='http://fonts.googleapis.com/css?family=Comfortaa'/>
+         href='//fonts.googleapis.com/css?family=Comfortaa'/>
 
     {%block head %}{% endblock %}
   </head>


### PR DESCRIPTION
fixing two http requests with // to fix these two msgs:

Blocked loading mixed active content "http://fonts.googleapis.com/css?family=Comfortaa"
Loading mixed (insecure) display content on a secure page "http://koji.fedoraproject.org/koji-static/images/header-bg.png"
