### PR TITLE
Fix the fas_login_required decorator

### DIFF
--- a/nuancier/__init__.py
+++ b/nuancier/__init__.py
@@ -92,6 +92,10 @@ def fas_login_required(function):
             flask.flash('Login required', 'errors')
             return flask.redirect(flask.url_for('.login',
                                                 next=flask.request.url))
+        elif not flask.g.fas_user.cla_done:
+            flask.flash('You must sign the CLA (Contributor License '
+                        'Agreement to use nuancier', 'errors')
+            return flask.redirect(flask.url_for('.index'))
         else:
             if len(flask.g.fas_user.groups) == 0:
                 flask.flash('You must be in one more group than the CLA',


### PR DESCRIPTION
The redirection to login is a bad idea has if the user is already logged in there,
fas-openid will redirect to nuancier which will redirect to fas-openid, creating an infinite
loop of redirection.

This commit should fix it.

Fixes #11
