### PR TITLE
Show Jenkins build status in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 nuancier
 ========
 
+.. image:: http://shieldkins.elrod.me/fedora/nuancier
+
 :Author: Pierre-Yves Chibon <pingou@pingoured.fr>
 
 


### PR DESCRIPTION
I made a [small tool](https://github.com/CodeBlock/shieldkins) to generate and
serve build status badges (by proxying to http://shields.io/) for a predefined
list of Jenkins servers. So we can do this now. :)
