### PR TITLE
Add some missing requirements to the dep list.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ Pillow
 SQLAlchemy>=0.6
 dogpile.cache
 blinker # required by flask for tests
+python-openid
+python-openid-cla
+python-openid-teams


### PR DESCRIPTION
I tried setting up nuancier in a fresh virtualenv with
`pip install -r requirements.txt`, but python-fedora didn't pull in these
deps.  We should add them here to make it as easy as possible for people to
hack on our apps.

Relates to #33.
