### PR TITLE
Fix incorrect FAS URLs

### DIFF
--- a/nuancier/templates/elections_list.html
+++ b/nuancier/templates/elections_list.html
@@ -15,7 +15,7 @@
 <p>
     <span class="warning">Only Fedora contributors can vote.</span>
     A contributor is defined by someone having an account on
-    <a href="https://admin.fedoraproject.org/account">FAS</a>, having signed
+    <a href="https://admin.fedoraproject.org/accounts">FAS</a>, having signed
     the <a href="https://fedoraproject.org/wiki/Legal:Fedora_Project_Contributor_Agreement"
     >FPCA</a> and being in one additional group.
 </p>

--- a/nuancier/templates/index.html
+++ b/nuancier/templates/index.html
@@ -52,7 +52,7 @@ wallpapers included in Fedora.
 <p>
 <span class="warning">Only Fedora contributors can vote.</span>
 A contributor is defined by someone having an account on
-<a href="https://admin.fedoraproject.org/account">FAS</a>, having signed
+<a href="https://admin.fedoraproject.org/accounts">FAS</a>, having signed
 the <a href="https://fedoraproject.org/wiki/Legal:Fedora_Project_Contributor_Agreement"
 >FPCA</a> and being in one additional group.
 </p>


### PR DESCRIPTION
I found a couple instances where the URL to the FAS page was pointing to
the wrong location.  This change fixes the URL to the right spot.

Signed-off-by: Micah Abbott <miabbott@redhat.com>