### PR TITLE
Add travis support and fix broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+ - "2.7"
+ - "3.4"
+ - "3.5"
+
+install:
+ - pip install --upgrade setuptools pip
+ - pip install -r test-requirements.txt
+ - pip install -e .
+script: python -m unittest2 discover
+
+matrix:
+  allow_failures:
+    - python: "3.4"
+    - python: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,12 @@ Setup script
 """
 
 # Required to build on EL6
-__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
-import pkg_resources
+__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']  # NOQA
+import pkg_resources  # NOQA
 
+from setuptools import setup
 import os
+import re
 import shutil
 
 
@@ -18,15 +20,39 @@ if os.path.exists('nuancier/static/cache'):
     shutil.rmtree('nuancier/static/cache')
 
 
-from setuptools import setup
-from nuancier import __version__
+def get_version():
+    """Get the current version of the hotness package"""
+    with open('nuancier/__init__.py', 'r') as fd:
+        regex = r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]'
+        version = re.search(regex, fd.read(), re.MULTILINE).group(1)
+    if not version:
+        raise RuntimeError('No version set in hotness/__init__.py')
+    return version
+
+
+def get_requirements(requirements_file='requirements.txt'):
+    """Get the contents of a file listing the requirements.
+
+    :arg requirements_file: path to a requirements file
+    :type requirements_file: string
+    :returns: the list of requirements, or an empty list if
+              `requirements_file` could not be opened or read
+    :return type: list
+    """
+
+    lines = open(requirements_file).readlines()
+    return [
+        line.rstrip().split('#')[0]
+        for line in lines
+        if not line.startswith('#')
+    ]
 
 
 setup(
     name='nuancier',
     description='A voting application for the supplementary wallpapers of '
                 'Fedora',
-    version=__version__,
+    version=get_version(),
     author='Pierre-Yves Chibon',
     author_email='pingou@pingoured.fr',
     maintainer='Pierre-Yves Chibon',
@@ -36,6 +62,6 @@ setup(
     url='https://github.com/fedora-infra/nuancier/',
     packages=['nuancier'],
     include_package_data=True,
-    install_requires=['Flask', 'SQLAlchemy>=0.6', 'wtforms', 'flask-wtf',
-                      'python-fedora', 'Pillow', 'dogpile.cache', 'blinker'],
+    install_requires=get_requirements(),
+    tests_require=get_requirements('test-requirements.txt'),
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,6 +22,7 @@
 '''
 nuancier tests.
 '''
+from __future__ import print_function
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
@@ -48,7 +49,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(
 from nuancier.lib import model
 
 DB_PATH = 'sqlite:///:memory:'
-PICTURE_FOLDER = os.path.join(os.path.dirname(__file__), 'pictures')
+PICTURE_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pictures')
 CACHE_FOLDER = os.path.join(os.path.dirname(__file__), 'cache')
 TODAY = datetime.utcnow().date()
 FAITOUT_URL = 'http://faitout.fedorainfracloud.org/'
@@ -59,7 +60,7 @@ if os.environ.get('BUILD_ID'):
         req = requests.get('%s/new' % FAITOUT_URL)
         if req.status_code == 200:
             DB_PATH = req.text
-            print 'Using faitout at: %s' % DB_PATH
+            print('Using faitout at: %s' % DB_PATH)
     except:
         pass
 
@@ -113,8 +114,8 @@ class Modeltests(unittest.TestCase):
             elif os.path.isfile(CACHE_FOLDER):
                 os.unlink(CACHE_FOLDER)
             else:
-                print >> sys.stderr, \
-                    'Check %s, it cannot be removed' % CACHE_FOLDER
+                print('Check %s, it cannot be removed' % CACHE_FOLDER,
+                      file=sys.stderr)
 
         self.session.rollback()
 


### PR DESCRIPTION
This fixes some installation problems due to the requirements.txt file
being out of sync with the setup.py.

Depending on how the tests were run, the test for the pictures endpoint
would fail because the path to the pictures folder would be incorrectly
calculated since it could be relative. This ensures the path is always
absolute.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>