### PR TITLE
Gets 'vagrant up' to work from fresh git clone

### DIFF
--- a/devel/ansible/roles/nuancier-dev/files/alembic.ini.devel
+++ b/devel/ansible/roles/nuancier-dev/files/alembic.ini.devel
@@ -1,0 +1,51 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = devel/alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+#sqlalchemy.url = driver://user:pass@localhost/dbname
+sqlalchemy.url = sqlite:////var/tmp/nuancier_lite.sqlite
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/devel/ansible/roles/nuancier-dev/tasks/main.yml
+++ b/devel/ansible/roles/nuancier-dev/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Install alembic.ini
   become_user: "{{ ansible_env.SUDO_USER }}"
-  copy: src=alembic.ini dest=/home/{{ ansible_env.SUDO_USER }}/alembic.ini
+  copy: src=alembic.ini.devel dest=/home/{{ ansible_env.SUDO_USER }}/alembic.ini
 
 
 # Add the virtualenv


### PR DESCRIPTION
Not sure if this is the preferred way to complete this.  I thought it was best to actually store this alembic.ini in the files directory of the ansible role.  The alternative was to traverse the parent directories to pull the alembic.ini.sample from the utility directory and then doing a lineinfile ansible command to adjust as needed.  Which seemed messy considering, I really want to touch that one as it was used by the spec file.

With this you can now perform a vagrant up from a pristine repo and also all local tests run successfully.  A few FlaskWTFDeprecationWarnings but no failures.

`Ran 56 tests in 4.878s

OK (SKIP=1)'
