### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/alembic/versions/7db0e24a2a85_add_submission_end_date.py
+++ b/alembic/versions/7db0e24a2a85_add_submission_end_date.py
@@ -28,7 +28,7 @@ def upgrade():
         ins = "UPDATE \"Elections\" SET "\
             "submission_date_end=election_date_start;"
         op.execute(ins)
-    except Exception, err:
+    except Exception as err:
         print 'ERROR', err
 
     ## Enforce the nullable=False


### PR DESCRIPTION
Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.