### PR TITLE
Add a title attribute to status image icons.

### DIFF
--- a/nuancier/templates/admin_index.html
+++ b/nuancier/templates/admin_index.html
@@ -39,9 +39,11 @@ and stop an existing election.
         <td>
             {% if election.submission_open %}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Submission open"
                 alt="Submission open"/>
             {% else %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Submission closed"
                 alt="Submission closed"/>
             {% endif %}
             {{ election.submission_date_start }}
@@ -49,9 +51,11 @@ and stop an existing election.
         <td>
             {% if election.election_open %}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Election open"
                 alt="Election open"/>
             {% else %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Election closed"
                 alt="Election closed"/>
             {% endif %}
             {{ election.election_date_start }}
@@ -59,9 +63,11 @@ and stop an existing election.
         <td>
             {% if election.election_public %}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Election's results published"
                 alt="Election's results published"/>
             {% else %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Election's results closed"
                 alt="Election's results closed"/>
             {% endif %}
             {{ election.election_date_end }}

--- a/nuancier/templates/admin_review.html
+++ b/nuancier/templates/admin_review.html
@@ -22,7 +22,7 @@
 
 <h3>Overview</h3>
 <p>Here below are presented all the candidates of the election {{ election.election_name }}
-from {{ election.election_year }}, regardless of wether they are valid
+from {{ election.election_year }}, regardless of whether they are valid
 candidates or not.
 </p>
 <p>
@@ -111,12 +111,15 @@ candidates or not.
         <td>
             {% if candidate.approved == true%}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Candidate approved"
                 alt="Candidate approved"/>
             {% elif candidate.denied == true %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Candidate denied"
                 alt="Candidate denied"/>
             {% else %}
             <img src="{{ url_for('static', filename='New.png') }}"
+                title="Candidate Pending Review"
                 alt="Candidate Pending Review"/>
             {% endif %}
         </td>

--- a/nuancier/templates/admin_review_ro.html
+++ b/nuancier/templates/admin_review_ro.html
@@ -22,7 +22,7 @@
 
 <h3>Overview</h3>
 <p>Here below are presented all the candidates of the election {{ election.election_name }}
-from {{ election.election_year }}, regardless of wether they are valid
+from {{ election.election_year }}, regardless of whether they are valid
 candidates or not.
 </p>
 <p>
@@ -97,12 +97,15 @@ candidates or not.
         <td>
             {% if candidate.approved == true%}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Candidate approved"
                 alt="Candidate approved"/>
             {% elif candidate.denied == true %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Candidate denied"
                 alt="Candidate denied"/>
             {% else %}
             <img src="{{ url_for('static', filename='New.png') }}"
+                title="Candidate Pending Review"
                 alt="Candidate Pending Review"/>
             {% endif %}
         </td>

--- a/nuancier/templates/contributions.html
+++ b/nuancier/templates/contributions.html
@@ -62,12 +62,15 @@
         <td>
             {% if candidate.approved == true %}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Candidate approved"
                 alt="Candidate approved"/>
             {% elif candidate.denied == true %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Candidate denied"
                 alt="Candidate denied"/>
             {% else %}
             <img src="{{ url_for('static', filename='New.png') }}"
+                title="Candidate pending review"
                 alt="Candidate pending review"/>
             {% endif %}
         </td>

--- a/nuancier/templates/elections_list.html
+++ b/nuancier/templates/elections_list.html
@@ -38,9 +38,11 @@
         <td>
             {% if election.submission_open %}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Submission open"
                 alt="Submission open"/>
             {% else %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Submission closed"
                 alt="Submission closed"/>
             {% endif %}
             {{ election.submission_date_start }}
@@ -48,9 +50,11 @@
         <td>
             {% if election.election_open %}
             <img src="{{ url_for('static', filename='Approved.png') }}"
+                title="Election open"
                 alt="Election open"/>
             {% else %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Election open"
                 alt="Election open"/>
             {% endif %}
             {{ election.election_date_start }}
@@ -59,10 +63,12 @@
             {% if election.election_public %}
             <a href="{{ url_for('results', election_id=election.id) }}">
                 <img src="{{ url_for('static', filename='Approved.png') }}"
+                    title="Election published"
                     alt="Election published"/>
             </a>
             {% else %}
             <img src="{{ url_for('static', filename='Denied.png') }}"
+                title="Election closed"
                 alt="Election closed"/>
             {% endif %}
             {{ election.election_date_end }}


### PR DESCRIPTION
This pull request updates the templates for image icons to add a title attribute that reflects the image's alt attribute. This helps desktop users in understanding the meaning of the status icons. 

This change was inspired by submitting a new wallpaper and having to inspect the element in order to find out that the question mark means that the submission is pending review. ("is new", basically).

Hopefully this trivial change will improve UX slightly.

I couldn't help myself and also fixed a small typo along the way.